### PR TITLE
Update to latest std lib, return socket from handleUpgrade method

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A WebSocket server library for <a href="https://deno.land">Deno</a>.
 The [raison d'être](https://en.wiktionary.org/wiki/raison_d%27%C3%AAtre) for this library is to provide a unified async iterator for the events of all connected WebSocket clients.
 
 **Note**: This WebSocket server is **not** an `EventEmitter` (i.e. it does not use events with callbacks like [websockets/ws](https://github.com/websockets/ws)).
-Instead, it specifies the [asyncIterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator) symbol and should be used in conjunction with a [`for await...of`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) loop, just like the [Deno http server](https://deno.land/std@0.53.0/http/server.ts).
+Instead, it specifies the [asyncIterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator) symbol and should be used in conjunction with a [`for await...of`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) loop, just like the [Deno http server](https://deno.land/std@0.89.0/http/server.ts).
 The iterator return values are of
 ```typescript
 type WebSocketServerEvent = {
@@ -44,7 +44,7 @@ listenAndServe(":8080", ({ socket, event }) => {
 
 ### Using an existing HTTP server
 ```typescript
-import { serve } from "https://deno.land/std@0.53.0/http/server.ts";
+import { serve } from "https://deno.land/std@0.89.0/http/server.ts";
 import { WebSocketServer } from "https://deno.land/x/websocket_server/mod.ts";
 
 const httpServer = serve(":8080");
@@ -59,7 +59,7 @@ for await (const { event, socket } of wss) {
 
 ### Multiple WebSocket servers sharing an existing HTTP server
 ```typescript
-import { serve } from "https://deno.land/std@0.53.0/http/server.ts";
+import { serve } from "https://deno.land/std@0.89.0/http/server.ts";
 import { WebSocketServer } from "https://deno.land/x/websocket_server/mod.ts";
 
 async function serverHandler(wss: WebSocketServer, message: string) {
@@ -99,13 +99,12 @@ Check out the example [echo/broadcast server](example_server.ts).
 ## FAQ
 
 ### How do I create a WebSocket client?
-This library provides a class only for WebSocket servers, not WebSocket clients, because it is straightforward to create clients with the [std/ws](https://deno.land/std@0.53.0/ws/) module.
+This library provides a class only for WebSocket servers, not WebSocket clients, because it is straightforward to create clients with the [WebSocket API](https://developer.mozilla.org/docs/Web/API/WebSockets_API).
 
 Here is a simple example:
 ```typescript
-import { connectWebSocket } from "https://deno.land/std@0.53.0/ws/mod.ts";
 try {
-  const socket = await connectWebSocket("ws://127.0.0.1:8080");
+  const socket = new WebSocket("ws://127.0.0.1:8080");
   for await (const event of socket) {
     console.log(event);
     if (typeof event === "string" && event === "Who is this?") {

--- a/mod.ts
+++ b/mod.ts
@@ -3,4 +3,4 @@ export {
 	isWebSocketPingEvent,
 	isWebSocketPongEvent,
 	isWebSocketCloseEvent,
-} from "https://deno.land/std@0.53.0/ws/mod.ts";
+} from "https://deno.land/std@0.89.0/ws/mod.ts";

--- a/queue.ts
+++ b/queue.ts
@@ -1,4 +1,4 @@
-import { deferred, Deferred } from "https://deno.land/std@0.53.0/async/mod.ts";
+import { deferred, Deferred } from "https://deno.land/std@0.89.0/async/mod.ts";
 
 export class Queue<T> {
 	private stopSignal: boolean;

--- a/server.ts
+++ b/server.ts
@@ -70,6 +70,7 @@ export class WebSocketServer {
 			);
 			this.trackSocket(socket);
 			this.handleSocketEvents(socket);
+			return socket;
 		} catch (err) {
 			console.error(err);
 			await req.respond({

--- a/server.ts
+++ b/server.ts
@@ -5,13 +5,13 @@ import {
 	ServerRequest,
 	HTTPOptions,
 	HTTPSOptions,
-} from "https://deno.land/std@0.53.0/http/server.ts";
+} from "https://deno.land/std@0.89.0/http/server.ts";
 import { Queue } from "./queue.ts";
 import {
 	acceptWebSocket,
 	WebSocket,
 	WebSocketEvent,
-} from "https://deno.land/std@0.53.0/ws/mod.ts";
+} from "https://deno.land/std@0.89.0/ws/mod.ts";
 
 type WebSocketServerEvent = {
 	event: WebSocketEvent;


### PR DESCRIPTION
To add compatibility with server frameworks, such as abc, where a request handler must stay open until the websocket is finished (otherwise the socket will be closed directly), I am returning the socket from the `handleUpgrade` method, so I can use the socket iterator in the abc `get('/ws', ...)` handler.

Furthermore, the std library is updated, as v0.53.0 doesn't work anymore with modern Deno versions.