### PR TITLE
Emit "connection" event on server when a socket connects

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -90,9 +90,10 @@ export class WebSocketServer {
 
 	// Adds WebSocket events to the queue
 	private async handleSocketEvents(socket: WebSocket) {
-		// TODO add a connection event which also exposes the http request?
+		// TODO also expose the http request?
+		this.queue.add({ event: 'connection', socket });
 		for await (const event of socket) {
-			this.queue.add({ socket, event } as WebSocketServerEvent);
+			this.queue.add({ socket, event });
 		}
 		// When socket is closed, the for await loop will be finished
 		this.untrackSocket(socket);

--- a/server_test.ts
+++ b/server_test.ts
@@ -33,7 +33,7 @@ test("that a `WebSocketServer` receives events from a client", async () => {
 	const results: { socket: WebSocket; event: WebSocketEvent; }[] = [];
 	saveIterationResults(results, server);
 
-	const msgsPerClient = 3;
+	const msgsPerClient = 4; // The three below plus "connection"
 	const client1 = new WebSocket(`ws://127.0.0.1:${port}`);
 	await new Promise(resolve => client1.addEventListener('open', resolve))
 	const client2 = new WebSocket(`ws://127.0.0.1:${port}`);
@@ -60,12 +60,14 @@ test("that a `WebSocketServer` receives events from a client", async () => {
 	assertEquals(results[1].socket, results[5].socket);
 	assertNotEquals(results[0].socket, results[1].socket);
 
-	assertEquals(results[0].event, "client 1");
-	assertEquals(results[1].event, "client 2");
-	assertEquals(results[2].event, new Uint8Array([1, 2, 3]));
-	assertEquals(results[3].event, new Uint8Array([4, 5, 6]));
-	assertEquals(results[4].event, { code: 3001, reason: "done" });
-	assertEquals(results[5].event, { code: 3002, reason: "done" });
+	assertEquals(results[0].event, "connection"); // client1
+	assertEquals(results[1].event, "connection"); // client2
+	assertEquals(results[2].event, "client 1");
+	assertEquals(results[3].event, "client 2");
+	assertEquals(results[4].event, new Uint8Array([1, 2, 3]));
+	assertEquals(results[5].event, new Uint8Array([4, 5, 6]));
+	assertEquals(results[6].event, { code: 3001, reason: "done" });
+	assertEquals(results[7].event, { code: 3002, reason: "done" });
 
 	await server.close();
 });


### PR DESCRIPTION
Fixes #8 

Adds server-side 'connection' event on socket connection (I hope that's obvious :smile:). This also exposes the `request` in all event payloads, I don't know if that is required, necessary or even wanted? Might be helpful to check for custom headers in a server implementation on certain message events?